### PR TITLE
Reverse the order by which variables are populated

### DIFF
--- a/lsb_release/src/lsb_release
+++ b/lsb_release/src/lsb_release
@@ -51,11 +51,11 @@
 # - changed Debian specifics, codename anticipates release num
 #
 # Description:
-# Collect information from sourceable /etc/lsb-release file (present on
-# LSB-compliant systems) : LSB_VERSION, DISTRIB_ID, DISTRIB_RELEASE,
-# DISTRIB_CODENAME, DISTRIB_DESCRIPTION (all optional)
+# Find and parse the /etc/[distro]-release file
+# Collect information from sourceable /etc/lsb-release file for overriding
+# (present on LSB-compliant systems) : LSB_VERSION, DISTRIB_ID,
+# DISTRIB_RELEASE, DISTRIB_CODENAME, DISTRIB_DESCRIPTION (all optional)
 # Then (if needed) find and add names from /etc/lsb-release.d
-# Then (if needed) find and parse the /etc/[distro]-release file
 
 
 ###############################################################################
@@ -274,13 +274,7 @@ EASE ($DISTRIB_CODENAME)"
 
 # Check missing and requested infos, then find the file and get infos
 GetDistribInfo() {
-    NO=""  # /etc/lsb-release data are enough to reply what is requested?
-    [ -n "$ARG_D" ] && [ -z "$DISTRIB_DESCRIPTION" ] && NO="y"
-    [ -z "$NO" ] && [ -n "$ARG_I" ] && [ -z "$DISTRIB_ID" ] && NO="y"
-    [ -z "$NO" ] && [ -n "$ARG_R" ] && [ -z "$DISTRIB_RELEASE" ] && NO="y"
-    [ -z "$NO" ] && [ -n "$ARG_C" ] && [ -z "$DISTRIB_CODENAME" ] && NO="y"
-
-    if [ -n "$NO" ]
+    if [ -n "$ARG_D" ] || [ -n "$ARG_I" ] || [ -n "$ARG_R" ] || [ -n "$ARG_C" ]
     then
         if [ ! -f "$CHECKFIRST" ]
         then
@@ -410,8 +404,8 @@ then
 fi
 
 # Initialization
-GetLSBInfo
 GetDistribInfo
+GetLSBInfo
 
 # Display requested infos (order as follow)
 [ -n "$ARG_V" ] && DisplayVersion

--- a/lsb_release/src/lsb_release.examples
+++ b/lsb_release/src/lsb_release.examples
@@ -89,5 +89,5 @@ Codename:       TryIt
 
 [REPORTING BUGS]
 Report bugs at http://bugs.linuxbase.org.
-Please include a complete, self contained example that will allow the
+Please include a complete, self-contained example that will allow the
 bug to be reproduced, and say which version of lsb_release you are using.


### PR DESCRIPTION
On Arch Linux, when asking for the description, we get it:
```
	$ ./lsb_release -d
	Description:    Arch Linux
```
But when we ask for the codename of the release as well, the description is set to "`(none)`".
```
	$ ./lsb_release -d -c
	Description:    (none)
	Codename:       n/a
```
This happens because when we request the codename, in `GetDistribInfo()`, we trigger the `InitDistribInfo()` logic when `-c` is given. This overrides the `DISTRIB_DESCRIPTION` variable that has been parsed from `/etc/lsb-release`.

However, according to `lsb_release/src/lsb_release.examples`:
```
	Optional fields are DISTRIB_ID, DISTRIB_RELEASE,
	DISTRIB_CODENAME, DISTRIB_DESCRIPTION and can be used to
	override information which is parsed from the
	"/etc/distrib-release" file.
```
This means that we're actually invoking `GetLSBInfo()` and `GetDistribInfo()` in reverse order. We should invoke `GetDistribInfo()` first so that it can be overridden by `GetLSBInfo()` later. Reverse the calling order of these two functions.

Since we've reversed the calling order, `GetDistribInfo()` will never have any of the variables populated when it's called so remove the checks for those.
